### PR TITLE
Fix interactive buttons not working on mobile

### DIFF
--- a/quotes/views.py
+++ b/quotes/views.py
@@ -159,7 +159,9 @@ def stock_info(request: HttpRequest):
     return mattermost_text(response)
 
 def mattermost_action(url: str, name: str, **params):
+    action_id = name.lower().replace(' ', '_')
     return {
+        "id": action_id,
         "name": name.capitalize(),
         "integration": {
             "url": url,


### PR DESCRIPTION
Actions had no explicit `id` field, causing Mattermost to generate random IDs each time the post was edited. The mobile client caches stale action IDs, leading to 404 "Invalid action id" errors when tapping buttons like Refresh. Setting deterministic IDs (e.g. "refresh", "day", "week") keeps them stable across edits.

💘 Generated with Crush

Assisted-by: Crush:glm-5.1