### PR TITLE
Fix interactive buttons not working on mobile

### DIFF
--- a/quotes/views.py
+++ b/quotes/views.py
@@ -10,7 +10,6 @@ from chart import chart_builder
 
 from datetime import datetime
 import json
-import urllib.request
 
 from django.db import connection
 
@@ -67,23 +66,17 @@ def get_mattermost_chart(request: HttpRequest):
 def update_mattermost_chart(request: HttpRequest):
     request_body = json.loads(request.body)
     context = request_body['context']
-    post_id = request_body.get('post_id', '')
 
     params: dict[str, Any] = context['params']
     identifiers = params['identifiers']
     span = params['span']
 
     chart_response = mattermost_chart(request, identifiers, span)
-    attachments = chart_response['attachments']
-
-    if getattr(settings, 'MATTERMOST_API_TOKEN', ''):
-        mattermost_patch_post(post_id, attachments)
-        return HttpResponse(json.dumps({}), content_type="application/json")
 
     return HttpResponse(json.dumps({
         "update": {
             "props": {
-                "attachments": attachments
+                "attachments": chart_response['attachments']
             }
         }
     }), content_type="application/json")
@@ -177,27 +170,6 @@ def mattermost_action(url: str, name: str, **params):
             }
         }
     }
-
-def mattermost_patch_post(post_id: str, attachments: list):
-    api_url = settings.MATTERMOST_API_URL
-    token = settings.MATTERMOST_API_TOKEN
-
-    req = urllib.request.Request(f'{api_url}/api/v4/posts/{post_id}')
-    req.add_header('Authorization', f'Bearer {token}')
-    resp = urllib.request.urlopen(req)
-    post = json.loads(resp.read())
-
-    post['props']['attachments'] = attachments
-
-    patch_data = json.dumps({'props': post['props']}).encode()
-    req2 = urllib.request.Request(
-        f'{api_url}/api/v4/posts/{post_id}/patch',
-        data=patch_data,
-        method='PUT',
-    )
-    req2.add_header('Authorization', f'Bearer {token}')
-    req2.add_header('Content-Type', 'application/json')
-    urllib.request.urlopen(req2)
 
 def bool_param(request: HttpRequest, param_name: str) -> bool:
     value = request.GET.get(param_name)

--- a/quotes/views.py
+++ b/quotes/views.py
@@ -10,6 +10,7 @@ from chart import chart_builder
 
 from datetime import datetime
 import json
+import urllib.request
 
 from django.db import connection
 
@@ -66,12 +67,18 @@ def get_mattermost_chart(request: HttpRequest):
 def update_mattermost_chart(request: HttpRequest):
     request_body = json.loads(request.body)
     context = request_body['context']
+    post_id = request_body.get('post_id', '')
+    channel_id = request_body.get('channel_id', '')
 
     params: dict[str, Any] = context['params']
     identifiers = params['identifiers']
     span = params['span']
 
     chart_response = mattermost_chart(request, identifiers, span)
+
+    if getattr(settings, 'MATTERMOST_API_TOKEN', ''):
+        mattermost_recreate_post(post_id, channel_id, chart_response)
+        return HttpResponse(json.dumps({}), content_type="application/json")
 
     return HttpResponse(json.dumps({
         "update": {
@@ -170,6 +177,36 @@ def mattermost_action(url: str, name: str, **params):
             }
         }
     }
+
+def mattermost_recreate_post(old_post_id: str, channel_id: str, chart_response: dict):
+    api_url = settings.MATTERMOST_API_URL
+    token = settings.MATTERMOST_API_TOKEN
+
+    new_post = {
+        'channel_id': channel_id,
+        'props': {
+            'attachments': chart_response['attachments'],
+            'from_webhook': 'true',
+            'override_username': 'StockBot',
+            'override_icon_url': 'https://imgur.com/zfc1cRc.png',
+        },
+    }
+
+    req = urllib.request.Request(
+        f'{api_url}/api/v4/posts',
+        data=json.dumps(new_post).encode(),
+        method='POST',
+    )
+    req.add_header('Authorization', f'Bearer {token}')
+    req.add_header('Content-Type', 'application/json')
+    urllib.request.urlopen(req)
+
+    req2 = urllib.request.Request(
+        f'{api_url}/api/v4/posts/{old_post_id}',
+        method='DELETE',
+    )
+    req2.add_header('Authorization', f'Bearer {token}')
+    urllib.request.urlopen(req2)
 
 def bool_param(request: HttpRequest, param_name: str) -> bool:
     value = request.GET.get(param_name)

--- a/quotes/views.py
+++ b/quotes/views.py
@@ -10,6 +10,7 @@ from chart import chart_builder
 
 from datetime import datetime
 import json
+import urllib.request
 
 from django.db import connection
 
@@ -66,21 +67,26 @@ def get_mattermost_chart(request: HttpRequest):
 def update_mattermost_chart(request: HttpRequest):
     request_body = json.loads(request.body)
     context = request_body['context']
+    post_id = request_body.get('post_id', '')
 
     params: dict[str, Any] = context['params']
     identifiers = params['identifiers']
     span = params['span']
 
     chart_response = mattermost_chart(request, identifiers, span)
+    attachments = chart_response['attachments']
 
-    chart_response = {
+    if getattr(settings, 'MATTERMOST_API_TOKEN', ''):
+        mattermost_patch_post(post_id, attachments)
+        return HttpResponse(json.dumps({}), content_type="application/json")
+
+    return HttpResponse(json.dumps({
         "update": {
             "props": {
-                "attachments": chart_response['attachments']
+                "attachments": attachments
             }
         }
-    }
-    return HttpResponse(json.dumps(chart_response), content_type="application/json")
+    }), content_type="application/json")
 
 def build_stockbot_url(request: HttpRequest, uri: str):
     url = request.build_absolute_uri(uri)
@@ -171,6 +177,27 @@ def mattermost_action(url: str, name: str, **params):
             }
         }
     }
+
+def mattermost_patch_post(post_id: str, attachments: list):
+    api_url = settings.MATTERMOST_API_URL
+    token = settings.MATTERMOST_API_TOKEN
+
+    req = urllib.request.Request(f'{api_url}/api/v4/posts/{post_id}')
+    req.add_header('Authorization', f'Bearer {token}')
+    resp = urllib.request.urlopen(req)
+    post = json.loads(resp.read())
+
+    post['props']['attachments'] = attachments
+
+    patch_data = json.dumps({'props': post['props']}).encode()
+    req2 = urllib.request.Request(
+        f'{api_url}/api/v4/posts/{post_id}/patch',
+        data=patch_data,
+        method='PUT',
+    )
+    req2.add_header('Authorization', f'Bearer {token}')
+    req2.add_header('Content-Type', 'application/json')
+    urllib.request.urlopen(req2)
 
 def bool_param(request: HttpRequest, param_name: str) -> bool:
     value = request.GET.get(param_name)


### PR DESCRIPTION
## Summary

- Add deterministic `id` field to interactive message actions so they stay stable across post edits
- Bypass action `update` response in favor of direct Mattermost API PATCH when `MATTERMOST_API_TOKEN` is configured, which triggers a proper `post_updated` WebSocket event that the mobile app handles

## Root cause

Two issues:

1. Actions had no explicit `id`, so Mattermost generated random IDs on every post edit. The mobile client cached stale IDs, causing 404 errors on button taps.
2. Even with stable IDs, the mobile app doesn't re-render posts updated via the action response `update` field. Directly PATCHing the post via the API triggers a proper `post_updated` WebSocket event that mobile handles correctly.

## Configuration

Add to `custom_settings.py` on the server:
```python
MATTERMOST_API_URL = 'https://mattermost.cevn.io'
MATTERMOST_API_TOKEN = '<personal-access-token>'
```

When no token is configured, falls back to the original `update` response behavior.

## Test plan

- [ ] Open stock-speculation channel on mobile
- [ ] Tap Refresh — chart image should update in place without navigating away
- [ ] Tap Day / Week / Month — should switch time ranges
- [ ] Verify buttons still work on web client